### PR TITLE
Update io.github.unicornyrainbow.secrets runtime to 46

### DIFF
--- a/io.github.unicornyrainbow.secrets.yml
+++ b/io.github.unicornyrainbow.secrets.yml
@@ -1,6 +1,6 @@
 app-id: io.github.unicornyrainbow.secrets
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: run.sh
 
@@ -27,4 +27,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/UnicornyRainbow/Secrets
-        commit: 6bfe60172f6293b51d08d9722d3b457cded4d9c0
+        commit: 0fc44f90f45495c848cc83611d04922f09135dec


### PR DESCRIPTION
- Update io.github.unicornyrainbow.secrets runtime to 46 since runtime version 44 has reached end-of-life.
- Update to the recent version that have some fixes.