### PR TITLE
fix exception when locale without ".UTF-8" and update to gnome 50

### DIFF
--- a/io.github.unicornyrainbow.secrets.yml
+++ b/io.github.unicornyrainbow.secrets.yml
@@ -1,6 +1,6 @@
 app-id: io.github.unicornyrainbow.secrets
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: run.sh
 
@@ -33,4 +33,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/UnicornyRainbow/Secrets
-        commit: 8ac6454d7d3f90af52de7320c26fbd660f499d83
+        commit: ffb1da2163e503bffb531c495750a03ec37d4e54


### PR DESCRIPTION
Fixed bug that prevented the app from starting for some locales on some systems
resolves unicornyrainbow/Secrets#11